### PR TITLE
Prevent imageView width and height from being reset

### DIFF
--- a/Core/Source/DTAttributedTextContentView.m
+++ b/Core/Source/DTAttributedTextContentView.m
@@ -324,8 +324,6 @@ static Class _layerClassToUseForDTAttributedTextContentView = nil;
 					if (existingAttachmentView)
 					{
 						existingAttachmentView.hidden = NO;
-						existingAttachmentView.frame = frameForSubview;
-						
 						existingAttachmentView.alpha = 1;
 						
 						[existingAttachmentView setNeedsLayout];

--- a/DTCoreText.podspec
+++ b/DTCoreText.podspec
@@ -1,9 +1,9 @@
 Pod::Spec.new do |spec|
   spec.name         = 'DTCoreText'
-  spec.version      = '1.6.24'
+  spec.version      = '1.6.25'
   spec.platforms    = {:ios => '4.3', :tvos => '9.0' }
   spec.license      = 'BSD'
-  spec.source       = { :git => 'https://github.com/Cocoanetics/DTCoreText.git', :tag => spec.version.to_s }
+  spec.source       = { :git => 'https://github.com/Expensify/DTCoreText.git', :tag => spec.version.to_s }
   spec.source_files = 'Core/Source/*.{h,m,c}'
   spec.ios.source_files = 'Core/Source/iOS/*.{h,m,c}'
   spec.dependency 'DTFoundation/Core', '~>1.7.5'


### PR DESCRIPTION
### Details
This PR prevents a LazyImageView frame from being set to the parent frame. More context in https://github.com/Expensify/Mobile-Expensify/pull/11792#issuecomment-672374930

### Tests
1. Check out https://github.com/Expensify/Mobile-Expensify/pull/11792 and pull down this branch
2. Inside `Podfile` in Mobile-Expensify, remove the current `DTCoreText` listing
3. Underneath `# Non-Binary (Don't pre-compile)`, add the following
   ```
   pod 'DTCoreText', :git => 'https://github.com/Expensify/DTCoreText.git', :branch => 'joe-image-dimensions'
   ```
4. Go to the Mobile-Expensify iOS directory and run `rm -rf Pods/DTCoreText`, and then run `rm Podfile.lock`, and then run `pod install`
   1. Once this is done running, check the podfile.lock and confirm that `DTCoreText` has version 1.6.25. If it doesn't, you can run the nuclear option of `rm -rf Podfile.lock Pods/` from the iOS directory, and then `pod install --repo-update`. This will take some time.
5. Once its done, run the iOS app and confirm that attachment images display properly like in the description of https://github.com/Expensify/Mobile-Expensify/pull/11792

**Note: Once this is merged we need to add a tag on master so we can easily reference this updated version in the Mobile-Expensify podfile** (step 3 in [this article](https://sebastiandobrincu.com/blog/how-to-update-your-cocoapods-library-version))